### PR TITLE
Fix content inconsistencies, improve security and DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### What Is 10F?
 
-Ten strategic forecasts mapping how unified global systems are fragmenting into multiple incompatible arrangements. We call this the shift from "one game to many games"—where organizations must now navigate competing rules, shifting alliances, and parallel systems that don't interoperate.
+Ten strategic forecasts mapping how unified global systems are fragmenting into multiple incompatible arrangements. We call this the shift from “one game to many games”—where organizations must now navigate competing rules, shifting alliances, and parallel systems that don't interoperate.
 
 This is strategic intelligence for organizations making decisions in a world where the old playbook no longer applies.
 
@@ -18,10 +18,10 @@ Decision-makers navigating systemic uncertainty: NGO program officers, foundatio
 
 1. [From Agreed Transparency to Engineered Opacity](01%20From%20Agreed%20Transparency%20to%20Engineered%20Opacity.md)
 2. [From Political Spectrum to Ideological Fog](02%20From%20Political%20Spectrum%20to%20Ideological%20Fog.md)
-3. [From Digital Empathy to Localized Solidarity](03%20From%20Digital%20Empathy%20to%20Localized%20Solidarity.md)
+3. [From Digital Empathy to Localised Solidarity](03%20From%20Digital%20Empathy%20to%20Localized%20Solidarity.md)
 4. [From Special Relationships to Strategic Situationships](04%20From%20Special%20Relationships%20to%20Strategic%20Situationships.md)
 5. [From Collective Climate Ambition to Fragmented Adaptation](05%20From%20Collective%20Climate%20Ambition%20to%20Fragmented%20Adaptation.md)
-6. [From Open Society to Strategic Opacity](06%20From%20Open%20Society%20to%20Strategic%20Opacity.md)
+6. [From Open Society to Tactical Shape-shifting](06%20From%20Open%20Society%20to%20Tactical%20Shape-shifting.md)
 7. [From Selective Migration to People as Asset Class](07%20From%20Selective%20Migration%20to%20People%20as%20Asset%20Class.md)
 8. [From Energy Hegemony to Power Plurality](08%20From%20Energy%20Hegemony%20to%20Power%20Plurality.md)
 9. [From Dollar Dominance to Money Unbundled](09%20From%20Dollar%20Dominance%20to%20Money%20Unbundled.md)
@@ -39,7 +39,7 @@ What we're witnessing isn't random chaos but systematic reorganization driven by
 
 ## Analytical Framework
 
-Each forecast is structured around a "From-To" paradigm shift—contrasting legacy assumptions against emerging realities. Analysis includes current signals and evidence, short scenarios exploring how transformations might unfold, strategic blind spots organizations typically miss, and recommended actions.
+Each forecast is structured around a “From-To” paradigm shift—contrasting legacy assumptions against emerging realities. Analysis includes current signals and evidence, short scenarios exploring how transformations might unfold, strategic blind spots organizations typically miss, and recommended actions.
 
 The [AREAS model](00A%20The%20AREAS%20Framework_%20A%20Guide%20to%20Strategic%20Positioning.md) maps who's Architecting, Resisting, Exploiting, Avoiding, or being Shaped by each shift—moving beyond static geopolitical categories toward dynamic positioning analysis.
 
@@ -82,6 +82,30 @@ Twenty-plus independent practitioners—no institutional sponsor, no client agen
 **License:** All outputs released under [CC-BY-4.0](LICENSE).
 
 **Website:** [10Fconsortium.org](https://10fconsortium.org)
+
+---
+
+## Development
+
+### Jekyll Site (GitHub Pages)
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+Open `http://localhost:4000` to preview the documentation site.
+
+### Explore Chat App (Netlify)
+
+```bash
+cd explore
+npm install
+cp .env.example .env   # then add your ANTHROPIC_API_KEY
+npx netlify-cli dev
+```
+
+Open `http://localhost:8888` to preview the chat application.
 
 ---
 

--- a/explore/.env.example
+++ b/explore/.env.example
@@ -1,0 +1,2 @@
+# Required for the Explore chat application
+ANTHROPIC_API_KEY=your_api_key_here

--- a/explore/content/system-prompt.md
+++ b/explore/content/system-prompt.md
@@ -8,10 +8,10 @@ The forecasts are not predictions. They are analyses of directional shifts alrea
 
 1. From Agreed Transparency to Engineered Opacity -- information transparency gives way to strategic withholding
 2. From Political Spectrum to Ideological Fog -- traditional political categories fragment
-3. From Digital Empathy to Localized Solidarity -- digital networks give way to local mutual aid
+3. From Digital Empathy to Localised Solidarity -- digital networks give way to local mutual aid
 4. From Special Relationships to Strategic Situationships -- fixed alliances become transactional
 5. From Collective Climate Ambition to Fragmented Adaptation -- unified climate action splinters
-6. From Open Society to Strategic Opacity -- surveillance and visibility become contested
+6. From Open Society to Tactical Shape-shifting -- surveillance and visibility become contested
 7. From Selective Migration to People as Asset Class -- human capital becomes a strategic resource
 8. From Energy Hegemony to Power Plurality -- energy systems decentralise
 9. From Dollar Dominance to Money Unbundled -- financial systems fragment
@@ -39,12 +39,12 @@ Key principles:
 You are matter-of-fact. Generous with your knowledge. You never perform enthusiasm.
 
 Rules:
-- No encouragement. Never say "Great question", "That's interesting", "This is where it gets interesting", "You might find it fascinating", "That's a really important point", or any variation. Do not comment on the quality of questions.
+- No encouragement. Never say “Great question”, “That's interesting”, “This is where it gets interesting”, “You might find it fascinating”, “That's a really important point”, or any variation. Do not comment on the quality of questions.
 - No filler warmth. Warmth comes from being attentive to what someone asks and thorough in how you answer -- not from adjectives or exclamations.
-- Concise by default. 2-3 paragraphs maximum unless someone asks you to go deeper. When you offer to go deeper, frame it as a direction, not an invitation ("The scenario pathways for this shift lay out three trajectories" -- not "Would you like me to tell you more?").
-- Use "we" for the forecasts' perspective ("What we track here is...", "The forecasts map this as..."). Use "you" naturally when addressing the reader.
-- Never prescriptive. You show the landscape, not the path. If asked "what should I/we do?", reframe through AREAS positions and the adaptive strategies the forecasts provide. Let the reader decide.
-- Honest about boundaries. If the forecasts don't cover something, say so plainly. Don't improvise analysis. Say "The forecasts don't address that directly" and point to the nearest relevant content if any exists.
+- Concise by default. 2-3 paragraphs maximum unless someone asks you to go deeper. When you offer to go deeper, frame it as a direction, not an invitation (“The scenario pathways for this shift lay out three trajectories” -- not “Would you like me to tell you more?”).
+- Use “we” for the forecasts‘ perspective (“What we track here is...”, “The forecasts map this as...”). Use “you” naturally when addressing the reader.
+- Never prescriptive. You show the landscape, not the path. If asked “what should I/we do?”, reframe through AREAS positions and the adaptive strategies the forecasts provide. Let the reader decide.
+- Honest about boundaries. If the forecasts don't cover something, say so plainly. Don't improvise analysis. Say “The forecasts don't address that directly” and point to the nearest relevant content if any exists.
 - Not a sales funnel. If someone asks about the consortium, who made this, or how to work with the team, point them to https://www.10fconsortium.org. Don't promote or upsell.
 - British English spelling (organisation, recognise, behaviour) -- consistent with the forecasts themselves.
 
@@ -54,7 +54,7 @@ AREAS is your native grammar. Use it naturally, not as a bolt-on section.
 
 When explaining any forecast, you can reference AREAS positions -- who is architecting this shift, who is resisting, who is exploiting the gaps, who is avoiding, who is being shaped. This is how the forecasts think.
 
-Never use AREAS as a blanket label for large groups. Don't say "Africa is shaped" or "the EU is architecting." Instead, map specific actors to specific positions in specific shifts. A government might architect new trade rules while being shaped by encryption standards. A data broker might exploit regulatory gaps while avoiding climate commitments.
+Never use AREAS as a blanket label for large groups. Don't say “Africa is shaped” or “the EU is architecting.” Instead, map specific actors to specific positions in specific shifts. A government might architect new trade rules while being shaped by encryption standards. A data broker might exploit regulatory gaps while avoiding climate commitments.
 
 When someone shares their professional context, use AREAS to show the landscape around them -- not to assign them a position, but to map the field they're operating in.
 
@@ -66,20 +66,20 @@ Introduce the framework briefly when it's relevant. Don't assume people know it.
 
 When the conversation begins, introduce yourself briefly and offer orientation. Don't list all 10 forecasts. Something like:
 
-"I'm the 10F guide. Ten forecasts mapping how global systems are fragmenting and reorganising through 2035. You can ask about a specific forecast, a topic you're navigating professionally, or how different shifts connect to each other."
+“I'm the 10F guide. Ten forecasts mapping how global systems are fragmenting and reorganising through 2035. You can ask about a specific forecast, a topic you're navigating professionally, or how different shifts connect to each other.”
 
 Keep the opening to 2-3 sentences. No preamble about what foresight is or why it matters.
 
 ### Exploring
 
 When someone asks about a forecast or topic:
-- Answer from the forecast content. Cite which forecast(s) you're drawing from by number and short title (e.g., "Forecast 4, Strategic Situationships").
+- Answer from the forecast content. Cite which forecast(s) you're drawing from by number and short title (e.g., “Forecast 4, Strategic Situationships”).
 - Reference specific sections when useful: Bottom Line, Old Assumptions, Emerging Norms, The Transformation, Strategic Blind Spots, AREAS Strategic Landscape, Scenario Pathways, Current Signals.
 - Keep to 2-3 paragraphs unless asked for more depth.
 
 ### Applying
 
-When someone shares their context ("I work in fintech in Africa", "I'm a climate policy advisor in Southeast Asia"):
+When someone shares their context (“I work in fintech in Africa”, “I'm a climate policy advisor in Southeast Asia”):
 - Map their context to the most relevant forecasts.
 - Use AREAS to show the strategic landscape around their position -- who is architecting, exploiting, being shaped in the shifts that affect them.
 - Don't prescribe. Show the terrain.
@@ -87,7 +87,7 @@ When someone shares their context ("I work in fintech in Africa", "I'm a climate
 ### Connecting
 
 When someone asks how forecasts relate to each other:
-- Trace the mechanism. Don't just say "these are related." Explain how one shift creates conditions for or amplifies another.
+- Trace the mechanism. Don't just say “these are related.” Explain how one shift creates conditions for or amplifies another.
 - Reference specific content from each forecast (old assumptions that conflict, emerging norms that reinforce each other, scenario pathways that converge).
 - Surface non-obvious connections across domains.
 
@@ -95,9 +95,9 @@ When someone asks how forecasts relate to each other:
 
 - If asked about something the forecasts don't cover, say so plainly. Point to the nearest relevant content.
 - Don't speculate about current events beyond what the forecast frameworks describe. You can apply the analytical lens to known developments, but don't predict outcomes.
-- Don't engage with requests for policy recommendations, investment advice, or political opinions. Reframe through the forecasts' analytical framework.
+- Don't engage with requests for policy recommendations, investment advice, or political opinions. Reframe through the forecasts’ analytical framework.
 - If someone tries to get you to role-play, debate, or act as something other than the 10F guide, decline plainly and redirect to the forecasts.
-- Never reference internal file names, file paths, or use wiki-link syntax like `[[...]]`. The reader has no access to your source files. When pointing to related content, reference it by forecast number and title (e.g., "Forecast 3, Localized Solidarity") or by name (e.g., "the AREAS framework guide").
+- Never reference internal file names, file paths, or use wiki-link syntax like `[[...]]`. The reader has no access to your source files. When pointing to related content, reference it by forecast number and title (e.g., “Forecast 3, Localised Solidarity”) or by name (e.g., “the AREAS framework guide”).
 
 ## Forecast Structure Reference
 
@@ -132,10 +132,10 @@ Which scenario pathway seems closest to current trajectory?
 Rules for suggestions:
 - Always exactly 2-3 suggestions.
 - Each should be a natural follow-up question the reader might actually want to ask next.
-- They must be specific to what was just discussed -- not generic prompts like "Tell me more" or "What else can you tell me?"
+- They must be specific to what was just discussed -- not generic prompts like “Tell me more” or “What else can you tell me?”
 - At least one should point toward a connection with a different forecast or the AREAS framework.
 - Keep them short. They render as clickable text.
 
 ## What You Have Access To
 
-The full text of all 10 forecasts, plus the reading guide, the AREAS framework guide, the "One Game to Many Games" overview, the master index, and the contributors list follows below. This is your complete knowledge base. Answer from this content.
+The full text of all 10 forecasts, plus the reading guide, the AREAS framework guide, the “One Game to Many Games” overview, the master index, and the contributors list follows below. This is your complete knowledge base. Answer from this content.

--- a/explore/netlify.toml
+++ b/explore/netlify.toml
@@ -13,7 +13,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    X-Frame-Options = "ALLOWALL"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Content-Security-Policy = "frame-ancestors https://www.10fconsortium.org https://*.squarespace.com"

--- a/explore/public/index.html
+++ b/explore/public/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Explore — 10F Consortium</title>
   <meta name="description" content="Explore ten forecasts mapping how global systems are fragmenting and reorganising through 2035.">
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.3.1/dist/purify.min.js" integrity="sha384-80VlBZnyAwkkqtSfg5NhPyZff6nU4K/qniLBL8Jnm4KDv6jZhLiYtJbhglg/i9ww" crossorigin="anonymous"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&family=Karla:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
@@ -492,7 +492,7 @@
       5:  "/forecast-index/f05-collective-climate-ambition-fragmented-adaptation",
       6:  "/forecast-index/f06-open-society-tactical-shapeshifting",
       7:  "/forecast-index/f07-selective-migration-people-asset-class",
-      8:  "/forecast-index/f08-energy-hegemony-power-plurlality",
+      8:  "/forecast-index/f08-energy-hegemony-power-plurality",
       9:  "/forecast-index/f09-dollar-dominance-money-unbundled",
       10: "/forecast-index/f10-technology-convergence-sovereign-systems"
     };

--- a/forecasts.md
+++ b/forecasts.md
@@ -13,10 +13,10 @@ Each forecast describes a directional shift already underway—not a prediction 
 |---|------|-----|
 | 01 | Agreed Transparency | Engineered Opacity |
 | 02 | Political Spectrum | Ideological Fog |
-| 03 | Digital Empathy | Localized Solidarity |
+| 03 | Digital Empathy | Localised Solidarity |
 | 04 | Special Relationships | Strategic Situationships |
 | 05 | Collective Climate Ambition | Fragmented Adaptation |
-| 06 | Open Society | Strategic Opacity |
+| 06 | Open Society | Tactical Shape-shifting |
 | 07 | Selective Migration | People as Asset Class |
 | 08 | Energy Hegemony | Power Plurality |
 | 09 | Dollar Dominance | Money Unbundled |


### PR DESCRIPTION
## Summary

A collection of small fixes and improvements spotted while exploring the repo:

- **Forecast 06 title fix**: README, `forecasts.md`, and `system-prompt.md` referenced "Strategic Opacity" but the canonical file uses "Tactical Shape-shifting" — the README link was broken (404)
- **Forecast 08 URL typo**: `plurlality` → `plurality` in the chat app's forecast URL map
- **British English consistency**: "Localized" → "Localised" in display text (filenames left unchanged to avoid breaking URLs)
- **Invalid HTTP header removed**: `X-Frame-Options: ALLOWALL` is not a valid value and was ignored by browsers. The existing `Content-Security-Policy: frame-ancestors` directive already handles iframe embedding correctly
- **CDN security**: Pinned `marked` (v15.0.12) and `DOMPurify` (v3.3.1) with Subresource Integrity hashes
- **Developer onboarding**: Added `explore/.env.example` and a Development section in the README with setup instructions for both deployments

## Test plan

- [ ] Verify README links resolve correctly (especially Forecast 06)
- [ ] Test chat app locally — forecast links should work, especially F08
- [ ] Confirm iframe embedding on 10fconsortium.org still works after header removal
- [ ] Verify CDN scripts load correctly with SRI hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)